### PR TITLE
Adding InputPin trait implementation for Alternate Pins

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -267,6 +267,20 @@ macro_rules! gpio {
                 }
             }
 
+            impl<MODE> InputPin for $PXx<Alternate<MODE>> {
+                type Error = Never;
+
+                fn is_high(&self) -> Result<bool, Never> {
+                    self.is_low().map(|v| !v)
+                }
+
+                fn is_low(&self) -> Result<bool, Never> {
+                    // NOTE(unsafe) atomic read with no side effects
+                    Ok(unsafe { (*$GPIOX::ptr()).idr
+                                  .read().bits() & (1 << self.i) } == 0)
+                }
+            }
+
             impl<MODE> ExtiPin for $PXx<Input<MODE>> {
                 /// Make corresponding EXTI line sensitive to this pin
                 fn make_interrupt_source(&mut self, syscfg: &mut SYSCFG) {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -492,8 +492,8 @@ macro_rules! usart {
                                 _ => PCE::ENABLED,
                             }).ps()
                             .variant(match config.parity {
-                                Parity::ParityOdd => PS::EVEN,
-                                _ => PS::ODD,
+                                Parity::ParityOdd => PS::ODD,
+                                _ => PS::EVEN,
                             })
                     });
 


### PR DESCRIPTION
Adding the InputPin trait for Alternate function GPIO pins. This is totally safe to do.